### PR TITLE
update for cairo 1.14.6

### DIFF
--- a/projects/cairo/cairo.vcxproj
+++ b/projects/cairo/cairo.vcxproj
@@ -192,6 +192,7 @@
     <ClInclude Include="..\..\cairo\src\cairo-image-info-private.h" />
     <ClInclude Include="..\..\cairo\src\cairo-image-surface-inline.h" />
     <ClInclude Include="..\..\cairo\src\cairo-image-surface-private.h" />
+    <ClInclude Include="..\..\cairo\src\cairo-line-private.h" />
     <ClInclude Include="..\..\cairo\src\cairo-list-inline.h" />
     <ClInclude Include="..\..\cairo\src\cairo-list-private.h" />
     <ClInclude Include="..\..\cairo\src\cairo-malloc-private.h" />
@@ -315,6 +316,7 @@
     <ClCompile Include="..\..\cairo\src\cairo-image-info.c" />
     <ClCompile Include="..\..\cairo\src\cairo-image-source.c" />
     <ClCompile Include="..\..\cairo\src\cairo-image-surface.c" />
+    <ClCompile Include="..\..\cairo\src\cairo-line.c" />    
     <ClCompile Include="..\..\cairo\src\cairo-lzw.c" />
     <ClCompile Include="..\..\cairo\src\cairo-mask-compositor.c" />
     <ClCompile Include="..\..\cairo\src\cairo-matrix.c" />


### PR DESCRIPTION
Add missing files, to prevent unknown external symbol errors of 'cairo_lines_compare_at_y'